### PR TITLE
Validate random ID inputs and extend CLI coverage

### DIFF
--- a/massgenqr/cli.py
+++ b/massgenqr/cli.py
@@ -212,6 +212,20 @@ def random_ids(count: int, *, length: int, alphabet: Sequence[str] | str) -> Lis
     seen = set()
     ids: List[str] = []
     alphabet_list = list(alphabet)
+    if not alphabet_list:
+        raise ValueError("alphabet must not be empty")
+    max_identifiers = len(alphabet_list) ** length
+    if count > max_identifiers:
+        raise ValueError(
+            "Cannot generate {count} unique identifiers from an alphabet of size {alphabet_size} "
+            "with identifier length {length}. Maximum distinct identifiers: {max_identifiers}."
+            .format(
+                count=count,
+                alphabet_size=len(alphabet_list),
+                length=length,
+                max_identifiers=max_identifiers,
+            )
+        )
     while len(ids) < count:
         identifier = "".join(choice(alphabet_list) for _ in range(length))
         if identifier in seen:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import sys
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from massgenqr import cli
+
+
+@pytest.fixture(autouse=True)
+def stub_dependencies(monkeypatch):
+    """Avoid importing heavy optional dependencies during tests."""
+
+    monkeypatch.setattr(cli, "ensure_dependencies", lambda: None)
+
+
+def test_main_parser_error_empty_alphabet(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["1", "--alphabet", ""])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "error: alphabet must not be empty" in captured.err
+
+
+def test_main_parser_error_count_exceeds_capacity(capsys):
+    with pytest.raises(SystemExit) as excinfo:
+        cli.main(["3", "--alphabet", "A", "--id-length", "1"])
+
+    assert excinfo.value.code == 2
+    captured = capsys.readouterr()
+    assert "Maximum distinct identifiers: 1" in captured.err


### PR DESCRIPTION
## Summary
- validate random ID generation by rejecting empty alphabets
- guard against requesting more identifiers than possible for the given alphabet and length
- add CLI tests ensuring parser errors are emitted for invalid random ID requests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d92b07881c8329a063f8aae92a756f